### PR TITLE
Fix Webscraper url bug

### DIFF
--- a/Webscraper/apilib/src/main/java/apilib/scrapers/FoodNetwork.kt
+++ b/Webscraper/apilib/src/main/java/apilib/scrapers/FoodNetwork.kt
@@ -8,7 +8,7 @@ class FoodNetwork : BaseScraper() {
      * Return the url given a keyword and page number
      */
     override fun getUrlForPage(page: Number, keyWord: String): String {
-        return "https://www.foodnetwork.com/search/$keyWord/p/$page/CUSTOM_FACET:RECIPE_FACET"
+        return "https://www.foodnetwork.com/search/$keyWord-/p/$page/CUSTOM_FACET:RECIPE_FACET"
     }
 
     /**


### PR DESCRIPTION
Unexpected behavior occurs sometimes if a dash is missing.